### PR TITLE
Added extra OrderStatus -> Pickup

### DIFF
--- a/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
+++ b/frontend/app/dashboard/src/classes/order-filters/StatusFilter.ts
@@ -15,6 +15,7 @@ export class StatusFilter implements Filter {
         switch (this.status) {
             case OrderStatus.Created: return this.invert ? "Niet nieuw" : "Nieuw";
             case OrderStatus.Prepared: return this.invert ? "Niet verwerkt" :"Verwerkt";
+            case OrderStatus.Pickup: return this.invert ? "Niet ophalen" :"Ophalen";
             case OrderStatus.Completed: return this.invert ? "Niet voltooid" :"Voltooid";
             case OrderStatus.Canceled: return this.invert ? "Niet geannuleerd" : "Geannuleerd";
         }
@@ -30,6 +31,7 @@ export class StatusFilter implements Filter {
 
         base.push(new StatusFilter(OrderStatus.Created, true))
         base.push(new StatusFilter(OrderStatus.Prepared, true))
+        base.push(new StatusFilter(OrderStatus.Pickup, true))
         base.push(new StatusFilter(OrderStatus.Completed, true))
         base.push(new StatusFilter(OrderStatus.Canceled, true))
 

--- a/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/OrderStatusContextMenu.vue
@@ -6,6 +6,9 @@
         <ContextMenuItem @click="markAs(OrderStatus.Prepared)">
             Verwerkt
         </ContextMenuItem>
+        <ContextMenuItem @click="markAs(OrderStatus.Pickup)">
+            Ophalen
+        </ContextMenuItem>
         <ContextMenuItem @click="markAs(OrderStatus.Completed)">
             Voltooid
         </ContextMenuItem>

--- a/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
+++ b/frontend/app/dashboard/src/views/dashboard/webshop/WebshopView.vue
@@ -115,6 +115,7 @@
                         <td>
                             <span v-if="order.order.payment && order.order.payment.status !== 'Succeeded'" class="style-tag warn">Niet betaald</span>
                             <span v-if="order.order.status == 'Prepared'" class="style-tag">Verwerkt</span>
+                            <span v-if="order.order.status == 'Pickup'" v-tooltip="'Ophalen'" class="success icon green" />
                             <span v-if="order.order.status == 'Completed'" v-tooltip="'Voltooid'" class="success icon green" />
                             <span v-if="order.order.status == 'Canceled'" v-tooltip="'Geannuleerd'" class="error icon canceled" />
                         </td>

--- a/frontend/app/webshop/src/views/orders/OrderView.vue
+++ b/frontend/app/webshop/src/views/orders/OrderView.vue
@@ -69,6 +69,7 @@
 
                         <template slot="right">
                             <span v-if="order.status == 'Prepared'" class="style-tag">Verwerkt</span>
+                            <span v-else-if="order.status == 'Pickup'" class="style-tag success">Ophalen</span>
                             <span v-else-if="order.status == 'Completed'" class="style-tag success">Voltooid</span>
                             <span v-else-if="order.status == 'Canceled'" class="style-tag error">Geannuleerd</span>
                             <span v-else>Geplaatst</span>

--- a/shared/structures/src/webshops/Order.ts
+++ b/shared/structures/src/webshops/Order.ts
@@ -7,6 +7,7 @@ import { Checkout } from './Checkout';
 export enum OrderStatus {
     Created = "Created",
     Prepared = "Prepared",
+    Pickup = "Pickup",
     Completed = "Completed",
     Canceled = "Canceled",
 }
@@ -16,6 +17,7 @@ export class OrderStatusHelper {
         switch (status) {
             case OrderStatus.Created: return "Nieuw"
             case OrderStatus.Prepared: return "Verwerkt"
+            case OrderStatus.Pickup: return "Ophalen"
             case OrderStatus.Completed: return "Voltooid"
             case OrderStatus.Canceled: return "Geannuleerd"
         }


### PR DESCRIPTION
"Ophalen" as extra status for orders. Buyers that check their order (email link) will the see the status as 'ophalen' and know they can come to collect.
This extra status option is also needed/useful for webshops that do not keep stock. 'Prepared'(=verwerkt) as a status would then mean it is passed on to the supplier.