### PR TITLE
Finetuning max persons for event

### DIFF
--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -250,18 +250,19 @@ export class Checkout extends AutoEncoder {
         // Check maximum
         if (timeSlot.remainingPersons !== null && this.cart.persons - this.reservedPersons > timeSlot.remainingPersons) {
             const remaingPersons = timeSlot.remainingPersons
+            const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
             if (remaingPersons === 0) {
                 throw new SimpleError({
                     code: "timeslot_full",
                     message: "Timeslot has reached maximum orders",
-                    human: "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk.",
+                    human: (availableTimeslots !=1 ? "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk." : "Het evenement is helaas volzet. We aanvaarden geen verdere bestellingen."),
                     field: "timeSlot"
                 })
             }
             throw new SimpleError({
                 code: "timeslot_full",
                 message: "Timeslot has reached maximum persons",
-                human: "Er "+(remaingPersons != 1 ? "zijn" : "is")+" nog maar "+remaingPersons+" "+(remaingPersons != 1 ? "plaatsen" : "plaats")+" vrij op het gekozen tijdstip. Jouw mandje is voor " + this.cart.persons + " "+(this.cart.persons != 1 ? "personen" : "persoon")+". Kies een ander tijdstip indien mogelijk.",
+                human: "Er "+(remaingPersons != 1 ? "zijn" : "is")+" nog maar "+remaingPersons+" "+(remaingPersons != 1 ? "plaatsen" : "plaats")+" vrij "+(availableTimeslots !=1 ? "op het gekozen tijdstip" : "voor dit evenement")+". Jouw mandje is voor " + this.cart.persons + " "+(this.cart.persons != 1 ? "personen" : "persoon")+(availableTimeslots !=1 ? ". Kies een ander tijdstip indien mogelijk." : ""),
                 field: "timeSlot"
             })
         }

--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -275,7 +275,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "invalid_first_name",
                 message: "Invalid first name",
-                human: "Het voornaam dat je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
+                human: "De voornaam die je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
                 field: "customer.firstName"
             })
         }
@@ -284,7 +284,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "invalid_last_name",
                 message: "Invalid last name",
-                human: "Het achternaam dat je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
+                human: "De achternaam die je hebt opgegeven is ongeldig, corrigeer het voor je verder gaat.",
                 field: "customer.lastName"
             })
         }

--- a/shared/structures/src/webshops/Checkout.ts
+++ b/shared/structures/src/webshops/Checkout.ts
@@ -227,6 +227,7 @@ export class Checkout extends AutoEncoder {
         
         const current = this.timeSlot
         const timeSlot = this.checkoutMethod.timeSlots.timeSlots.find(s => s.id == current.id)
+        const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
         
         if (!timeSlot) {
             throw new SimpleError({
@@ -242,7 +243,7 @@ export class Checkout extends AutoEncoder {
             throw new SimpleError({
                 code: "timeslot_full",
                 message: "Timeslot has reached maximum orders",
-                human: "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk.",
+                human: (availableTimeslots !=1 ? "Het gekozen tijdstip is helaas volzet. Kies een ander tijdstip indien mogelijk." : "Het evenement is helaas volzet. We aanvaarden geen verdere bestellingen."),
                 field: "timeSlot"
             })
         }
@@ -250,7 +251,6 @@ export class Checkout extends AutoEncoder {
         // Check maximum
         if (timeSlot.remainingPersons !== null && this.cart.persons - this.reservedPersons > timeSlot.remainingPersons) {
             const remaingPersons = timeSlot.remainingPersons
-            const availableTimeslots = this.checkoutMethod.timeSlots.timeSlots.length
             if (remaingPersons === 0) {
                 throw new SimpleError({
                     code: "timeslot_full",


### PR DESCRIPTION
2 spelling updates and a small tweak to the code to not mention timeslots when there is only one avaialble timeslot. 
The webshop will just tell the user the event is full. Mentioning selecting other timeslots when none have initially been shown to the user (because there is only one timeslot), will confuse the user.